### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: 10up/embed-block-figma/.github/workflows/build-release-zip.yml@develop
@@ -19,6 +26,7 @@ jobs:
     if: always()
 
     strategy:
+      fail-fast: false
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Embed Block for Figma ===
 Contributors:      10up, dkotter, jeffpaul
 Tags:              gutenberg, figma, embed, blocks, custom blocks
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        0.4.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1 RC1. The plugin functions as expected with the 7.1 RC1

Closes #91 

### How to test the Change

1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Create a post with embed figma file
3.  Block embeds the figma file correctly both on editor and frontend
4. No error message in browser console

### Changelog Entry
> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits
Props @oscarssanchezz 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
